### PR TITLE
Config File bug-fix

### DIFF
--- a/run_hive.py
+++ b/run_hive.py
@@ -49,8 +49,11 @@ def main():
     #shared resource
     sessions = {}
 
-    public_ip = config.get('public_ip', 'public_ip')
-    fetch_ip = config.getboolean('public_ip', 'fetch_public_ip')
+    try:
+        public_ip = config.get('public_ip', 'public_ip')
+        fetch_ip = config.getboolean('public_ip', 'fetch_public_ip')
+    except:
+        print "Problem parsing config file [hive.cfg]. (Does it exist in the proper place?)"
 
     #greenlet to consume the provided sessions
     sessions_consumer = consumer.Consumer(sessions, public_ip=public_ip, fetch_public_ip=fetch_ip)


### PR DESCRIPTION
Fixed crash if config file doesn't exist (or has bad syntax). An informative error message is printed now.
