### PR TITLE
CRAM-MD5 support for SMTP capability: Added announcement

### DIFF
--- a/hive/capabilities/smtp.py
+++ b/hive/capabilities/smtp.py
@@ -85,7 +85,7 @@ class SMTPChannel(smtpd.SMTPChannel):
             self.push('503 Duplicate HELO/EHLO')
         else:
             self.push('250-%s Hello %s' % (self.banner, arg))
-            self.push('250-AUTH PLAIN LOGIN')
+            self.push('250-AUTH PLAIN LOGIN CRAM-MD5')
             self.push('250 EHLO')
 
     def smtp_AUTH(self, arg):


### PR DESCRIPTION
The capability now broadcasts the CRAM-MD5 support, previously it only broadcasted support for PLAIN and LOGIN mechanisms.
